### PR TITLE
Add %license macro to packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,4 +40,5 @@
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
 
-packageBuildingPipelineDAOS(['distros': ['centos7', 'leap15']])
+packageBuildingPipelineDAOS(['distros': ['centos7', 'leap15'],
+                            'publish_branch': 'release/0.9'])

--- a/dpdk.spec
+++ b/dpdk.spec
@@ -45,9 +45,13 @@ Summary: Set of libraries and drivers for fast packet processing
 #
 # Note that, while this is dual licensed, all code that is included with this
 # Pakcage are BSD licensed. The only files that aren't licensed via BSD is the
-# kni kernel module which is dual LGPLv2/BSD, and thats not built for fedora.
+# kni kernel module which is dual LGPLv2/BSD, and thats not built.
 #
+%if (0%{?suse_version} > 0)
+License: BSD-3-Clause and LGPLv2 and GPLv2
+%else
 License: BSD and LGPLv2 and GPLv2
+%endif
 
 #
 # The DPDK is designed to optimize througput of network traffic using, among
@@ -269,6 +273,7 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 
 %files
 # BSD
+%license license/README
 %doc README MAINTAINERS
 %dir %{pmddir}
 %{_libdir}/*.so.*
@@ -278,6 +283,7 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 
 %files doc
 #BSD
+%license license/README
 %if (0%{?rhel} >= 7)
 %{docdir}
 %else
@@ -288,6 +294,7 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 
 %files devel
 #BSD
+%license license/README
 %{incdir}/
 %{sdkdir}/
 %if %{with tools}
@@ -313,6 +320,10 @@ sed -i -e 's:-%{machine_tmpl}-:-%{machine}-:g' %{buildroot}/%{_sysconfdir}/profi
 %endif
 
 %changelog
+* Tue Jun 16 2020 Brian J. Murrell <brian.murrell@intel.com> - 0:19.02-3
+- Add %license macro to packages
+- Update License: for SUSE builds
+
 * Fri Mar 13 2020 Brian J. Murrell <brian.murrell@intel.com> - 0:19.02-2
 - Disable CONFIG_RTE_LIBRTE_MLX[45]_PMD for DAOS/spdk
 


### PR DESCRIPTION

Update License: for SUSE builds.

license/README contains:
The DPDK uses the Open Source BSD-3-Clause license for the core libraries and
drivers. The kernel components are naturally GPL-2.0 licensed.

Including big blocks of License headers in all files blows up the
source code with mostly redundant information.  An additional problem
is that even the same licenses are referred to by a number of
slightly varying text blocks (full, abbreviated, different
indentation, line wrapping and/or white space, with obsolete address
information, ...) which makes validation and automatic processing a nightmare.

To make this easier, DPDK uses a single line reference to Unique License
Identifiers in source files as defined by the Linux Foundation's SPDX project
(https://spdx.org/).

Adding license information in this fashion, rather than adding full license
text, can be more efficient for developers; decreases errors; and improves
automated detection of licenses. The current set of valid, predefined SPDX
identifiers is set forth on the SPDX License List at https://spdx.org/licenses/.

DPDK uses first line of the file to be SPDX tag. In case of *#!* scripts, SPDX
tag can be placed in 2nd line of the file.

For example, to label a file as subject to the BSD-3-Clause license,
the following text would be used:

SPDX-License-Identifier: BSD-3-Clause

To label a file as GPL-2.0 (e.g., for code that runs in the kernel), the
following text would be used:

SPDX-License-Identifier: GPL-2.0

To label a file as dual-licensed with BSD-3-Clause and GPL-2.0 (e.g., for code
that is shared between the kernel and userspace), the following text would be
used:

SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)

To label a file as dual-licensed with BSD-3-Clause and LGPL-2.1 (e.g., for code
that is shared between the kernel and userspace), the following text would be
used:

SPDX-License-Identifier: (BSD-3-Clause OR LGPL-2.1)

Any new file contributions in DPDK shall adhere to the above scheme.
It is also being recommended to replace the existing license text in the code
with SPDX-License-Identifiers.

Any exception to the DPDK IP policies shall be approved by DPDK Tech Board and
DPDK Governing Board. Steps for any exception approval:
1. Mention the appropriate license identifier form SPDX. If the license is not
   listed in SPDX Licenses. It is the submitters responsibiliity to get it
   first listed.
2. Get the required approval from the DPDK Technical Board. Technical Board may
   advise the author to check alternate means first. If no other alternative
   are found and the merit of the contributions are important for DPDK's
   mission, it may decide on such exception with two-thirds vote of the members.
3. Technical Board then approach Governing Board for such limited approval for
   the given contribution only.

Any approvals shall be documented in "Licenses/exceptions.txt" with record
dates.

DPDK project supported licenses are:

1. BSD 3-clause "New" or "Revised" License
	SPDX-License-Identifier: BSD-3-Clause
	URL: http://spdx.org/licenses/BSD-3-Clause#licenseText
	DPDK License text: licenses/bsd-3-clause.txt
2. GNU General Public License v2.0 only
	SPDX-License-Identifier: GPL-2.0
	URL: http://spdx.org/licenses/GPL-2.0.html#licenseText
	DPDK License text: licenses/gpl-2.0.txt
3. GNU Lesser General Public License v2.1
	SPDX-License-Identifieri: LGPL-2.1
	URL: http://spdx.org/licenses/LGPL-2.1.html#licenseText
	DPDK License text: licenses/lgpl-2.1.txt

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>