### PR TITLE
DAOS-8008: Disable IOAT driver in build

### DIFF
--- a/dpdk.spec
+++ b/dpdk.spec
@@ -10,7 +10,7 @@
 
 Name: dpdk
 Version: 21.05
-Release: 3%{?dist}
+Release: 4%{?dist}
 Epoch: 0
 URL: http://dpdk.org
 Source: https://fast.dpdk.org/rel/dpdk-%{version}.tar.xz
@@ -127,7 +127,7 @@ end
 CFLAGS="$(echo %{optflags} -fcommon)" \
 %meson --includedir=include/dpdk \
        -Ddrivers_install_subdir=dpdk-pmds \
-       -Ddisable_drivers=compress/isal,compress/mlx5,net/mlx4,net/mlx5,vdpa/mlx5,common/mlx5,regex/mlx5 \
+       -Ddisable_drivers=compress/isal,compress/mlx5,net/mlx4,net/mlx5,vdpa/mlx5,common/mlx5,regex/mlx5,raw/ioat \
 %if %{with examples}
        -Dexamples=all \
 %endif
@@ -193,6 +193,9 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %endif
 
 %changelog
+* Wed Sep 08 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.05-4
+- Disable ioat driver.
+
 * Tue Aug 03 2021 Tom Nabarro <tom.nabarro@intel.com> - 0:21.05-3
 - Add additional patches to align with commit pinned by SPDK v21.07.
 

--- a/packaging/Dockerfile.centos.7
+++ b/packaging/Dockerfile.centos.7
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #

--- a/packaging/Dockerfile.coverity
+++ b/packaging/Dockerfile.coverity
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 #
 # 'recipe' for Docker to build for a Coverity scan.
 #

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -7,11 +7,22 @@ IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 repo_adds=()
 repo_dels=()
 
+
+
+
+: "${DISTRO_NAME:=$DISTRO}"
+if [[ "${CHROOT_NAME}" = epel-8-* ]]; then
+    : "${DAOS_STACK_CENTOS_8_VERSION:=8}"
+    DISTRO_NAME="centos-${DAOS_STACK_CENTOS_8_VERSION}"
+elif [[ "${CHROOT_NAME}" = opensuse-leap-15* ]]; then
+    : "${DAOS_STACK_LEAP_15_VERSION:=15.3}"
+    DISTRO_NAME="opensuse-${DAOS_STACK_LEAP_15_VERSION}"
+fi
 : "${REPOSITORY_URL:=}"
 if [ -n "$REPOSITORY_URL" ] && [ -n "$DISTRO_REPOS" ]; then
     repo_dels+=("--disablerepo=\*")
 elif [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
-    # Special code to force buiding on CentOS 8.3
+    # Special code to force building on CentOS 8.3
     if [ "${DOT_VER}" -eq 3 ]; then
         repo_dels+=("--disablerepo=\*")
         repo_base='http://mirror.centos.org/centos/8.3.2011/'
@@ -56,7 +67,7 @@ for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     repo_adds+=("--enablerepo $repo:$branch:$build_number")
     echo -e "[$repo:$branch:$build_number]\n\
 name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/\n\
+baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO_NAME/\n\
 enabled=1\n\
 gpgcheck=False\n" >> "$cfg_file"
 done


### PR DESCRIPTION
DAOS doesn't use DPDK's IOAT driver and we are seeing unsupressable
logging from the module. Remove the driver from the build.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>