### PR TITLE
DAOS-11032 build: Update DPDK to v21.11.2 to align with SPDK v22.01.2

### DIFF
--- a/0001-crypto-increase-RTE_CRYPTO_MAX_DEVS-to-accomodate-QA.patch
+++ b/0001-crypto-increase-RTE_CRYPTO_MAX_DEVS-to-accomodate-QA.patch
@@ -1,7 +1,7 @@
-From 078817b677a16cd13317ecee0521182676eccba9 Mon Sep 17 00:00:00 2001
+From 1a43924573025ee91508e2fd9b9cb0d34a10a6bd Mon Sep 17 00:00:00 2001
 From: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Date: Tue, 18 Jan 2022 14:50:37 +0100
-Subject: [PATCH 1/6] crypto: increase RTE_CRYPTO_MAX_DEVS to accomodate QAT
+Subject: [PATCH 1/7] crypto: increase RTE_CRYPTO_MAX_DEVS to accomodate QAT
  SYM and ASYM VFs
 
 In SPDK Jenkins CI the QAT devices only support 16VFs.
@@ -16,11 +16,11 @@ SPDK provides isa-l submodule with -I and -L.
 
 Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Change-Id: Ic9e22155564b2d1e6f685bac0f958836da4fc13b
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/11139
-Reviewed-by: Jim Harris <james.r.harris@intel.com>
-Reviewed-by: Ben Walker <benjamin.walker@intel.com>
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12497
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/11139 (spdk-21.11)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12497 (spdk-21.11.1)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14308
 Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
 ---
  config/rte_config.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/0002-isal-compile-compress_isal-PMD-without-system-wide-l.patch
+++ b/0002-isal-compile-compress_isal-PMD-without-system-wide-l.patch
@@ -1,18 +1,18 @@
-From dac5ce7793024118f97fecfeea2144e9a7a0e1bc Mon Sep 17 00:00:00 2001
+From 7aacaea225efc2e99369c7319090a4dc87702564 Mon Sep 17 00:00:00 2001
 From: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Date: Thu, 20 Jan 2022 16:36:55 +0100
-Subject: [PATCH 2/6] isal: compile compress_isal PMD without system-wide
+Subject: [PATCH 2/7] isal: compile compress_isal PMD without system-wide
  libisal
 
 SPDK provides isa-l submodule with -I and -L.
 
 Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Change-Id: I99924fc161a876ef017b9cdeeee52e2aed30d8ec
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/11180
-Reviewed-by: Jim Harris <james.r.harris@intel.com>
-Reviewed-by: Ben Walker <benjamin.walker@intel.com>
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12498
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/11180 (spdk-21.11)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12498 (spdk-21.11.1)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14309
 Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
 ---
  drivers/compress/isal/meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/0003-Revert-vhost-fix-missing-virtqueue-lock-protection.patch
+++ b/0003-Revert-vhost-fix-missing-virtqueue-lock-protection.patch
@@ -1,0 +1,41 @@
+From 78a4258c52e545793be9eb7d7a06febcd5004162 Mon Sep 17 00:00:00 2001
+From: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+Date: Wed, 21 Sep 2022 15:43:48 +0200
+Subject: [PATCH 3/7] Revert "vhost: fix missing virtqueue lock protection"
+
+This reverts commit 78414da84eb5f5ae3594a073bdc978d3e14efeb4.
+
+Please see issue https://github.com/spdk/spdk/issues/2518
+
+Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+Change-Id: If475db9c14f3b52a280f18ee87251cbc6fdd9304
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14601
+Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+---
+ lib/vhost/vhost.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/lib/vhost/vhost.c b/lib/vhost/vhost.c
+index 24f94495c6..fde1cfdfb0 100644
+--- a/lib/vhost/vhost.c
++++ b/lib/vhost/vhost.c
+@@ -1299,15 +1299,11 @@ rte_vhost_vring_call(int vid, uint16_t vring_idx)
+ 	if (!vq)
+ 		return -1;
+ 
+-	rte_spinlock_lock(&vq->access_lock);
+-
+ 	if (vq_is_packed(dev))
+ 		vhost_vring_call_packed(dev, vq);
+ 	else
+ 		vhost_vring_call_split(dev, vq);
+ 
+-	rte_spinlock_unlock(&vq->access_lock);
+-
+ 	return 0;
+ }
+ 
+-- 
+2.31.1
+

--- a/0004-meson-mlx5-Suppress-Wunused-value-diagnostic.patch
+++ b/0004-meson-mlx5-Suppress-Wunused-value-diagnostic.patch
@@ -1,7 +1,7 @@
-From 716915151d7b7dd319b7b2e0d88952a993abeb69 Mon Sep 17 00:00:00 2001
+From eab31108581a20f6909e6a802962e5c43360e28e Mon Sep 17 00:00:00 2001
 From: Alexey Marchuk <alexeymar@mellanox.com>
 Date: Thu, 15 Jul 2021 18:39:27 +0300
-Subject: [PATCH 3/6] meson/mlx5: Suppress -Wunused-value diagnostic
+Subject: [PATCH 4/7] meson/mlx5: Suppress -Wunused-value diagnostic
 
 mlx5 common library checks if several symbols/definitions
 are presented in system header files. If some are not
@@ -37,14 +37,13 @@ Signed-off-by: Alexey Marchuk <alexeymar@mellanox.com>
 Signed-off-by: Krzysztof Karas <krzysztof.karas@intel.com>
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/8795 (spdk-21.05)
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/9219 (spdk-21.08)
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/10451
-Tested-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
-Reviewed-by: Jim Harris <james.r.harris@intel.com>
-Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/10451 (spdk-21.11)
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12499
+(spdk-21.11.1)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14310
 Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
-Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
 ---
  drivers/common/mlx5/linux/meson.build | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/0005-ARM64-Cross-Compilation-Support.patch
+++ b/0005-ARM64-Cross-Compilation-Support.patch
@@ -1,7 +1,7 @@
-From 8652795b22e7c7ee5639b1ac2b8a6186f8a6d2ed Mon Sep 17 00:00:00 2001
+From 3712ca572d659dc6033899ea1cfc6ed7ba306bf4 Mon Sep 17 00:00:00 2001
 From: Krishna Kanth Reddy <krish.reddy@samsung.com>
 Date: Wed, 14 Jul 2021 13:03:31 +0530
-Subject: [PATCH 4/6] ARM64: Cross-Compilation Support
+Subject: [PATCH 5/7] ARM64: Cross-Compilation Support
 
 Modified the Configuration file to use the latest ARM Cross-Compiler.
 
@@ -16,31 +16,30 @@ Signed-off-by: Krzysztof Karas <krzysztof.karas@intel.com>
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/8778 (spdk-21.05)
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/9218 (spdk-21.08)
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/10450 (spdk-21.11)
-Tested-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
-Reviewed-by: Jim Harris <james.r.harris@intel.com>
-Reviewed-by: Ben Walker <benjamin.walker@intel.com>
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12500
-Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
-Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
+(spdk-21.11.1)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14311
 Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
 ---
  config/arm/arm64_armv8_linux_gcc  | 10 +++++-----
  drivers/compress/isal/meson.build |  4 ++++
  2 files changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/config/arm/arm64_armv8_linux_gcc b/config/arm/arm64_armv8_linux_gcc
-index 5391d35389..5d8813ee66 100644
+index 5c32f6b9ca..4f56798fae 100644
 --- a/config/arm/arm64_armv8_linux_gcc
 +++ b/config/arm/arm64_armv8_linux_gcc
 @@ -1,9 +1,9 @@
  [binaries]
 -c = 'aarch64-linux-gnu-gcc'
--cpp = 'aarch64-linux-gnu-cpp'
+-cpp = 'aarch64-linux-gnu-g++'
 -ar = 'aarch64-linux-gnu-gcc-ar'
 -strip = 'aarch64-linux-gnu-strip'
 -pkgconfig = 'aarch64-linux-gnu-pkg-config'
 +c = 'aarch64-none-linux-gnu-gcc'
-+cpp = 'aarch64-none-linux-gnu-cpp'
++cpp = 'aarch64-none-linux-gnu-g++'
 +ar = 'aarch64-none-linux-gnu-gcc-ar'
 +strip = 'aarch64-none-linux-gnu-strip'
 +pkgconfig = 'aarch64-none-linux-gnu-pkg-config'

--- a/0006-meson-remove-checks-for-optional-libraries.patch
+++ b/0006-meson-remove-checks-for-optional-libraries.patch
@@ -1,7 +1,7 @@
-From 94b83ac2a440f7f7fd16f402040bc2421e173c38 Mon Sep 17 00:00:00 2001
+From 0559a0eff6f7c1c10e4adf28a73a8e079b82c8b1 Mon Sep 17 00:00:00 2001
 From: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Date: Wed, 1 Dec 2021 11:39:08 +0100
-Subject: [PATCH 5/6] meson: remove checks for optional libraries
+Subject: [PATCH 6/7] meson: remove checks for optional libraries
 
 Very few libraries in DPDK are marked as optional.
 For SPDK when most of the drivers are disabled,
@@ -13,12 +13,13 @@ libraries.
 
 Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Change-Id: I60fbc7307a4f33482025a3b3c00948c091d236ff
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/10540
-Reviewed-by: Jim Harris <james.r.harris@intel.com>
-Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/10540 (spdk-21.11)
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12501
-Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+(spdk-21.11.1)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14312
 Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
 ---
  lib/meson.build | 4 ----
  1 file changed, 4 deletions(-)

--- a/0007-build-disable-apps-and-usertools.patch
+++ b/0007-build-disable-apps-and-usertools.patch
@@ -1,7 +1,7 @@
-From e981f07a3b01b99c9efddd4ae5cce764a677dba7 Mon Sep 17 00:00:00 2001
+From 744e58cca9556e59c65d3993115c6f034d57c4f2 Mon Sep 17 00:00:00 2001
 From: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Date: Wed, 1 Dec 2021 13:49:30 +0100
-Subject: [PATCH 6/6] build: disable apps and usertools
+Subject: [PATCH 7/7] build: disable apps and usertools
 
 There is no way to disable DPDK apps or usertools
 via meson. Disabling tests is possible and already done,
@@ -12,11 +12,13 @@ increasing build time and size (~2.5G).
 
 Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>
 Change-Id: I7362360cc43289207724d470ac46c9ddfb7b9105
-Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/11239
-Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
-Reviewed-by: Jim Harris <james.r.harris@intel.com>
-Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/11239 (spdk-21.11)
 Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/12502
+(spdk-21.11.1)
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/dpdk/+/14313
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+Reviewed-by: Konrad Sztyber <konrad.sztyber@intel.com>
 ---
  meson.build | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dpdk (21.11.2-1) unstable; urgency=high
+
+  [ Tom Nabarro ]
+  * Update DPDK to 21.11.2 to align with the SPDK 22.01.2 release.
+  * Add additional patches to align with commit pinned by SPDK 22.01.2.
+
+ -- Tom Nabarro <tom.nabarro@intel.com>  Thu, 24 Nov 2022 10:50:11 -0400
+
 dpdk (21.11.1-1) unstable; urgency=high
 
   [ Tom Nabarro ]
@@ -5,7 +13,6 @@ dpdk (21.11.1-1) unstable; urgency=high
   * Add additional patches to align with commit pinned by SPDK 22.01.1.
 
  -- Tom Nabarro <tom.nabarro@intel.com>  Mon, 11 Jul 2022 10:50:11 -0400
-
 
 dpdk (21.05-2) unstable; urgency=high
 

--- a/dpdk.spec
+++ b/dpdk.spec
@@ -7,7 +7,7 @@
 %global _vpath_builddir %{_vendor}-%{_target_os}-build
 
 Name: dpdk
-Version: 21.11.1
+Version: 21.11.2
 Release: 1%{?dist}
 Epoch: 0
 URL: http://dpdk.org
@@ -27,10 +27,11 @@ License: BSD and LGPLv2 and GPLv2
 
 Patch0: 0001-crypto-increase-RTE_CRYPTO_MAX_DEVS-to-accomodate-QA.patch
 Patch1: 0002-isal-compile-compress_isal-PMD-without-system-wide-l.patch
-Patch2: 0003-meson-mlx5-Suppress-Wunused-value-diagnostic.patch
-Patch3: 0004-ARM64-Cross-Compilation-Support.patch
-Patch4: 0005-meson-remove-checks-for-optional-libraries.patch
-Patch5: 0006-build-disable-apps-and-usertools.patch
+Patch2: 0003-Revert-vhost-fix-missing-virtqueue-lock-protection.patch
+Patch3: 0004-meson-mlx5-Suppress-Wunused-value-diagnostic.patch
+Patch4: 0005-ARM64-Cross-Compilation-Support.patch
+Patch5: 0006-meson-remove-checks-for-optional-libraries.patch
+Patch6: 0007-build-disable-apps-and-usertools.patch
 
 #
 # The DPDK is designed to optimize througput of network traffic using, among
@@ -171,6 +172,10 @@ CFLAGS="$(echo %{optflags} -fcommon)" \
 %endif
 
 %changelog
+* Thu Nov 24 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.11.2-1
+- Update DPDK to 21.11.2 to align with the SPDK 22.01.2 release.
+- Add additional patches to align with commit pinned by SPDK 22.01.2.
+
 * Mon Jul 11 2022 Tom Nabarro <tom.nabarro@intel.com> - 0:21.11.1-1
 - Update DPDK to 21.11.1 to align with the SPDK 22.01.1 release.
 - Add additional patches to align with commit pinned by SPDK 22.01.1.

--- a/packaging/Dockerfile.ubuntu.20.04
+++ b/packaging/Dockerfile.ubuntu.20.04
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             autoconf bash ca-certificates curl debhelper dh-make        \
             dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
             make patch pbuilder pkg-config python3-dev python3-distro   \
-            python3-distutils rpm scons wget
+            python3-distutils rpm scons wget cmake valgrind
 
 # rpmdevtools
 RUN echo "deb [trusted=yes] ${REPO_URL}${REPO_UBUNTU_20_04} focal main" > /etc/apt/sources.list.d/daos-stack-ubuntu-stable-local.list


### PR DESCRIPTION
Update DPDK packaging to version 21.11.2 to align with SPDK 22.01.2.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>